### PR TITLE
NPT-241/Update k8s ingress

### DIFF
--- a/helm/chart/templates/controller/ingressclass.yml
+++ b/helm/chart/templates/controller/ingressclass.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: {{ .Values.controller.ingressClassName }}


### PR DESCRIPTION
Transition k8s ingress API from `networking.k8s.io/v1beta1` to `networking.k8s.io/v1`