### PR TITLE
NPT-242/Enforce TLS in all X-Forwarded headers

### DIFF
--- a/helm/chart/files/rules.yml
+++ b/helm/chart/files/rules.yml
@@ -7,6 +7,7 @@ http:
         # Enforce TLS for incoming requests (as terminated after AWS ELB)
         customRequestHeaders:
           X-Forwarded-Scheme: "https"
+          X-Scheme: "https"
         # Enforce security headers for outgoing responses
         # (https://observatory.mozilla.org/)
         browserXssFilter: true


### PR DESCRIPTION
No possibillity to map a custom forwarded header (e.g. `X-Forwarded-Scheme`) for the original request scheme in JupyterHub **v3.*** new configuration.
Only the `X-Forwarded-Proto` and `X-Scheme` headers are currently supported.

Unfortunately, `X-Forwarded-Proto` is already part of the `X-Forwarded-*` headers' family, automatically added by Traefik onto the proxied requests after TLS termination at the load balancer (and set as `HTTP`).

https://discourse.jupyter.org/t/requires-any-of-read-servers-not-derived-from-scopes/15701

https://github.com/jupyterhub/jupyterhub/blob/02dead8ab1ad53655bdb461d9d7f94b52f2ecbec/jupyterhub/utils.py#L743-L778