### PR TITLE
NOOS-533/unique-rbac-role

### DIFF
--- a/helm/chart/templates/controller/rbac.yml
+++ b/helm/chart/templates/controller/rbac.yml
@@ -8,7 +8,7 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: traefik-controller
+  name: {{ .Values.controller.ingressClassName }}-controller
 subjects:
   - kind: ServiceAccount
     name: traefik-controller
@@ -16,12 +16,12 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: traefik-controller
+  name: {{ .Values.controller.ingressClassName }}-controller
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: traefik-controller
+  name: {{ .Values.controller.ingressClassName }}-controller
 rules:
   - apiGroups: [""]
     resources: ["services", "endpoints", "secrets"]


### PR DESCRIPTION
# Description
Correct helm chart to allow dynamically setting the rbac role name, so that it is unique

**JIRA Reference:** [NOOS-533](https://noosenergy.atlassian.net/browse/NOOS-533) 

[NOOS-533]: https://noosenergy.atlassian.net/browse/NOOS-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ