### PR TITLE
NOOS-1183/upgrade-traefik-v2

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,10 +1,10 @@
-# v2.10 resources:
+# v2.11 resources:
 #     - Traefik config
-#     https://doc.traefik.io/traefik/v2.10/
+#     https://doc.traefik.io/traefik/v2.11/
 #     - Helm chart
 #     https://github.com/traefik/traefik-helm-chart/tree/master/traefik
 #     - CRDs / ingresses
-#     https://github.com/traefik/traefik/tree/v2.10/pkg/provider/kubernetes/ingress/fixtures
+#     https://github.com/traefik/traefik/tree/v2.11/pkg/provider/kubernetes/ingress/fixtures
 rbac:
   enabled: true
 
@@ -14,7 +14,7 @@ controller:
   isDefaultIngressClass: true
   image:
     repository: traefik
-    tag: "v2.10"
+    tag: "v2.11.28"
     pullPolicy: Always
   service:
     annotations: {}


### PR DESCRIPTION
# Description

* Active support: https://doc.traefik.io/traefik/deprecation/releases/
* Change logs v2: https://doc.traefik.io/traefik/v2.11/migration/v2/

PS: unsure if the behaviour of allowing cross-namespace middlewares is still supported with `v2.11.*`, especially

https://github.com/noosenergy/noos-kube-proxy/blob/ea0b45ab826fa7cdd8839f3293df572e0b917940/helm/chart/files/config.yml#L17

Required to add security HTTP headers automatically to all our cluster outgoing HTTP responses

* middleware reference: https://github.com/noosenergy/noos-kube-proxy/blob/ea0b45ab826fa7cdd8839f3293df572e0b917940/helm/chart/files/config.yml#L32
* middleware definition: https://github.com/noosenergy/noos-kube-proxy/blob/ea0b45ab826fa7cdd8839f3293df572e0b917940/helm/chart/files/rules.yml#L6

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-1183](https://noosenergy.atlassian.net/browse/NOOS-1183)


[NOOS-1183]: https://noosenergy.atlassian.net/browse/NOOS-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ